### PR TITLE
Add missing indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Note: steps assume mainnet
 1) `\q`
 1) Modify the env variables in `.env` if needed (ex: connecting to local node instead of remote)
 1) Run the env file (`set -a; . .env; set +a`) 
-1) `cargo migrate up`
+1) `cargo migrate up` (you can debug migration by adding a `-v` at the end of the command)
 1) `cargo run`
 
 ### Migrations

--- a/migration/src/m20220210_000002_create_transaction_table.rs
+++ b/migration/src/m20220210_000002_create_transaction_table.rs
@@ -45,6 +45,16 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Column::IsValid).boolean().not_null())
                     .to_owned(),
             )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-transaction-block")
+                    .col(Column::BlockId)
+                    .to_owned(),
+            )
             .await
     }
 

--- a/migration/src/m20220211_000002_create_tx_credential_table.rs
+++ b/migration/src/m20220211_000002_create_tx_credential_table.rs
@@ -45,6 +45,26 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Column::Relation).integer().not_null())
                     .to_owned(),
             )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-tx_credential-stake_credential")
+                    .col(Column::CredentialId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-tx_credential-transaction")
+                    .col(Column::TxId)
+                    .to_owned(),
+            )
             .await
     }
 

--- a/migration/src/m20220211_000004_create_address_credential_table.rs
+++ b/migration/src/m20220211_000004_create_address_credential_table.rs
@@ -45,6 +45,26 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Column::Relation).integer().not_null())
                     .to_owned(),
             )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-address_credential-address")
+                    .col(Column::AddressId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-address_credential-stake_credential")
+                    .col(Column::CredentialId)
+                    .to_owned(),
+            )
             .await
     }
 

--- a/migration/src/m20220211_000005_create_transaction_output_table.rs
+++ b/migration/src/m20220211_000005_create_transaction_output_table.rs
@@ -32,8 +32,7 @@ impl MigrationTrait for Migration {
                         ForeignKey::create()
                             .name("fk-transaction_output-address_id")
                             .from(Entity, Column::AddressId)
-                            .to(Address, AddressColumn::Id)
-                            .on_delete(ForeignKeyAction::Cascade),
+                            .to(Address, AddressColumn::Id),
                     )
                     .col(ColumnDef::new(Column::TxId).integer().not_null())
                     .foreign_key(
@@ -44,6 +43,26 @@ impl MigrationTrait for Migration {
                             .on_delete(ForeignKeyAction::Cascade),
                     )
                     .col(ColumnDef::new(Column::OutputIndex).big_integer().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-transaction_output-address")
+                    .col(Column::AddressId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-transaction_output-transaction")
+                    .col(Column::TxId)
                     .to_owned(),
             )
             .await

--- a/migration/src/m20220211_000006_create_transaction_input_table.rs
+++ b/migration/src/m20220211_000006_create_transaction_input_table.rs
@@ -45,6 +45,26 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(Column::InputIndex).integer().not_null())
                     .to_owned(),
             )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-transaction_input-transaction_output")
+                    .col(Column::UtxoId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .table(Entity)
+                    .name("index-transaction_input-transaction")
+                    .col(Column::TxId)
+                    .to_owned(),
+            )
             .await
     }
 

--- a/migration/src/main.rs
+++ b/migration/src/main.rs
@@ -4,22 +4,19 @@ use std::fs;
 
 #[async_std::main]
 async fn main() {
-    let postgres_host = std::env::var("POSTGRES_HOST")
-        .expect("env POSTGRES_HOST not found");
-    let postgres_port = std::env::var("POSTGRES_PORT")
-        .expect("env POSTGRES_PORT not found");
-    let postgres_db = std::env::var("POSTGRES_DB")
-        .expect("env POSTGRES_DB not found");
+    let postgres_host = std::env::var("POSTGRES_HOST").expect("env POSTGRES_HOST not found");
+    let postgres_port = std::env::var("POSTGRES_PORT").expect("env POSTGRES_PORT not found");
+    let postgres_db = std::env::var("POSTGRES_DB").expect("env POSTGRES_DB not found");
 
-    let postgres_user_file = std::env::var("POSTGRES_USER_FILE")
-        .expect("env POSTGRES_USER_FILE not found");
-    let postgres_password_file = std::env::var("POSTGRES_PASSWORD_FILE")
-        .expect("env POSTGRES_PASSWORD_FILE not found");
+    let postgres_user_file =
+        std::env::var("POSTGRES_USER_FILE").expect("env POSTGRES_USER_FILE not found");
+    let postgres_password_file =
+        std::env::var("POSTGRES_PASSWORD_FILE").expect("env POSTGRES_PASSWORD_FILE not found");
 
-    let postgres_user = fs::read_to_string(postgres_user_file)
-        .expect("Cannot read POSTGRES_USER_FILE");
-    let postgres_password = fs::read_to_string(postgres_password_file)
-        .expect("Cannot read POSTGRES_PASSWORD_FILE");
+    let postgres_user =
+        fs::read_to_string(postgres_user_file).expect("Cannot read POSTGRES_USER_FILE");
+    let postgres_password =
+        fs::read_to_string(postgres_password_file).expect("Cannot read POSTGRES_PASSWORD_FILE");
 
     let url = format!("postgresql://{postgres_user}:{postgres_password}@{postgres_host}:{postgres_port}/{postgres_db}");
 

--- a/src/postgres_sink.rs
+++ b/src/postgres_sink.rs
@@ -137,7 +137,10 @@ impl<'a> Config<'a> {
                         .filter(BlockColumn::Slot.gt(block_slot))
                         .exec(self.conn)
                         .await?;
-                    tracing::info!("Rollback to slot {}", block_slot - 1);
+                    match block_slot {
+                        0 => tracing::info!("Rollback to genesis"),
+                        _ => tracing::info!("Rollback to slot {}", block_slot - 1),
+                    }
                 }
                 _ => (),
             }


### PR DESCRIPTION
Close #10 

We were missing indices on foreign keys which was causing perf issues

Time to sync epoch #0 went down from ~600sec -> ~220sec

In practice, tx input now seems comparable to the other inserts, so the largest perf bottleneck is the oura/cardano-node overhead.